### PR TITLE
Rewrite @import paths like we do url() paths

### DIFF
--- a/css.js
+++ b/css.js
@@ -24,6 +24,13 @@ if(isProduction()) {
 				return "url(" + steal.joinURIs( load.address, part) + ")";
 			});
 
+			// Replace @import's that don't start with a "u" or "U" and do start
+			// with a single or double quote with a path wrapped in "url()"
+			// relative to the page
+			source = source.replace(/@import [^uU]['"]?([^'"\)]*)['"]?/g, function(whole, part) {
+				return "@import url(" + steal.joinURIs( load.address, part) + ")";
+			});
+
 			if(load.source && typeof document !== "undefined") {
 				var doc = document.head ? document : document.getElementsByTagName ?
 					document : document.documentElement;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	"devDependencies":{
 		"bower":"^1.4.1",
 		"grunt": "^0.4.5",
-		"steal":"stealjs/steal#605-locate-path-schemes",
+		"steal":"^0.15.0",
 		"testee": "^0.2.5",
 		"systemjs":"bitovi/systemjs#b664e4cd359c013acb3445627d1e1e1799424542"
 	},

--- a/test/css_paths/folder/bootstrap/button-danger.css
+++ b/test/css_paths/folder/bootstrap/button-danger.css
@@ -1,0 +1,3 @@
+.btn-danger {
+  background-color: #f00;
+}

--- a/test/css_paths/folder/bootstrap/button.css
+++ b/test/css_paths/folder/bootstrap/button.css
@@ -1,0 +1,5 @@
+.btn {
+  display: inline-block;
+  padding: 5px;
+  background: #ccc;
+}

--- a/test/css_paths/folder/main.css
+++ b/test/css_paths/folder/main.css
@@ -1,6 +1,9 @@
+@import "locate://bootstrap/button.css";
+@import url("locate://bootstrap/button-danger.css");
+
 #test-element {
-  background-image: url("../images/hero-ribbons.png");
+	background-image: url("../images/hero-ribbons.png");
 }
 #test-relative {
-  background-image: url("locate://bootstrap/other.png");
+	background-image: url("locate://bootstrap/other.png");
 }

--- a/test/css_paths/main.js
+++ b/test/css_paths/main.js
@@ -1,5 +1,5 @@
 import "css_paths/folder/main.css!";
-
+import helpers from 'helpers';
 
 var testImage = function(selector, cb){
 	var image = new Image();
@@ -15,28 +15,35 @@ var testImage = function(selector, cb){
 	image.src = $(selector).css("background-image").replace(/url\("?/,"").replace(/"?\)/,"");
 };
 
-if (typeof window !== "undefined" && window.QUnit) {
-	testImage("#test-element", function(err){
-		if(err){
-			QUnit.ok(false, err);
-			QUnit.start();
-			removeMyself();
-		} else {
-			QUnit.ok(true, "#test-element");
-			testImage("#test-relative", function(err){
-				if(err){
-					QUnit.ok(false, err);
-				} else {
-					QUnit.ok(true, "#test-relative");
-				}
+// Wait for the @import's to resolve in the <style>
+// tag added by the main.css! import
+helpers.waitForCssRules($('style')[0], function () {
+	if (typeof window !== "undefined" && window.QUnit) {
+
+		var btn = $('.btn.btn-danger');
+		QUnit.equal(btn.css('display'), 'inline-block', '@import "locate://"; styles applied');
+		QUnit.equal(btn.css('backgroundColor'), 'rgb(255, 0, 0)', '@import url("locate://"); styles applied');
+
+		testImage("#test-element", function(err){
+			if(err){
+				QUnit.ok(false, err);
 				QUnit.start();
 				removeMyself();
-			});
-		}
-		
-	});
-	
-} else {
-	console.log("background-image", $("#test-element").css("background-image"));
-	console.log("tilde", $("#test-relative").css("background-image"));
-}
+			} else {
+				QUnit.ok(true, "background-image: url(../); styles applied");
+				testImage("#test-relative", function(err){
+					if(err){
+						QUnit.ok(false, err);
+					} else {
+						QUnit.ok(true, "background-image: url(locate://); styles applied");
+					}
+					QUnit.start();
+					removeMyself();
+				});
+			}
+		});
+	} else {
+		console.log("background-image", $("#test-element").css("background-image"));
+		console.log("tilde", $("#test-relative").css("background-image"));
+	}
+});

--- a/test/css_paths/site.html
+++ b/test/css_paths/site.html
@@ -2,6 +2,7 @@
 	<script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
 	<div id="test-element">CSS</div>
 	<div id="test-relative">CSS</div>
+	<div class="btn btn-danger">BUTTON</div>
 	<script>
 		window.QUnit = window.parent.QUnit;
 		window.removeMyself = window.parent.removeMyself;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,27 @@
+export default {
+	waitForCssRules: function (styleNode, callback) {
+		if (typeof callback !== 'function') {
+			throw new Error('No callback provided');
+		}
+
+		// Poll for confirmation that the styles have loaded
+		var poller = setInterval(function() {
+			var rulesLoaded = false;
+
+			try {
+				// Only populated when file is loaded
+				styleNode.sheet.cssRules;
+
+				// Set a flag that can be evaluated outside the try/catch
+				// block without throwing an error; Otherwise errors in the
+				// callback will be caught
+				rulesLoaded = true;
+			} catch (e){}
+
+			if (rulesLoaded) {
+				clearInterval(poller);
+				callback();
+			}
+		}, 10);
+	}
+}


### PR DESCRIPTION
- Added regex replacement for `@import "[path]"` pattern
- Added `@import "[path]"` test
- Added `@import url("[path]")` test
- Created a helper that waits for `<style>` tags to finish loading `@import` statements
- Deferred running tests until after `@import`'s are loaded
- Rewrote existing test messages to be more descriptive

Closes #12.