### PR TITLE
CSS instantiated

### DIFF
--- a/css.js
+++ b/css.js
@@ -9,7 +9,6 @@ var waitSeconds = (loader.cssOptions && loader.cssOptions.timeout)
 	? parseInt(loader.cssOptions.timeout, 10) : 60;
 var noop = function () {};
 var onloadCss = function(link, cb){
-	debugger;
 	var styleSheets = document.styleSheets,
 		i = styleSheets.length;
 	while( i-- ){

--- a/css.js
+++ b/css.js
@@ -9,6 +9,7 @@ var waitSeconds = (loader.cssOptions && loader.cssOptions.timeout)
 	? parseInt(loader.cssOptions.timeout, 10) : 60;
 var noop = function () {};
 var onloadCss = function(link, cb){
+	debugger;
 	var styleSheets = document.styleSheets,
 		i = styleSheets.length;
 	while( i-- ){
@@ -21,16 +22,26 @@ var onloadCss = function(link, cb){
 	});
 };
 
-
 if(isProduction()) {
 	exports.fetch = function(load) {
 		// inspired by https://github.com/filamentgroup/loadCSS
+
+		var styleSheets = document.styleSheets;
 
 		// wait until the css file is loaded
 		return new Promise(function(resolve, reject) {
 			var timeout = setTimeout(function() {
 				reject('Unable to load CSS');
 			}, waitSeconds * 1000);
+
+			// if found a stylesheet with the same address
+			// resolve this promise without adding a link element to the page.
+			for (var i = 0; i < styleSheets.length; ++i) {
+				if(load.address === styleSheets[i].href){
+					resolve('');
+					return;
+				}
+			}
 
 			var link = document.createElement('link');
 			link.type = 'text/css';

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "qunitjs": "~1.12.0",
-    "steal": "1.0.0-beta.3",
-    "steal-tools": "1.0.0-beta.3",
+    "steal": "^1.0.0-rc",
+    "steal-tools": "^1.0.0-rc",
     "systemjs": "bitovi/systemjs#b664e4cd359c013acb3445627d1e1e1799424542",
     "testee": "^0.2.5"
   },

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "qunitjs": "~1.12.0",
-    "steal": "1.0.0-beta.3",
-    "steal-tools": "1.0.0-beta.3",
+    "steal": "^1.0.0-beta.3",
+    "steal-tools": "^1.0.0-beta.3",
     "systemjs": "bitovi/systemjs#b664e4cd359c013acb3445627d1e1e1799424542",
     "testee": "^0.2.5"
   },

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "qunitjs": "~1.12.0",
-    "steal": "^1.0.0-beta.3",
-    "steal-tools": "^1.0.0-beta.3",
+    "steal": "1.0.0-beta.3",
+    "steal-tools": "1.0.0-beta.3",
     "systemjs": "bitovi/systemjs#b664e4cd359c013acb3445627d1e1e1799424542",
     "testee": "^0.2.5"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build-1": "node test/css_paths/build.js",
     "build-2": "node node_modules/.bin/steal-tools build --config test/css-before-js/stealconfig.js --main main --baseUrl test/css-before-js/ --minify false",
-    "test": "npm run build-1 && npm run build-2 && grunt test"
+    "build-3": "node test/css-instantiated/build.js",
+    "test": "npm run build-1 && npm run build-2 && npm run build-3 && grunt test"
   },
   "repository": {
     "type": "git",
@@ -26,12 +27,13 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "qunitjs": "~1.12.0",
-    "steal": "^1.0.0-beta",
-    "steal-tools": "^1.0.0-beta",
+    "steal": "1.0.0-beta.3",
+    "steal-tools": "1.0.0-beta.3",
     "systemjs": "bitovi/systemjs#b664e4cd359c013acb3445627d1e1e1799424542",
     "testee": "^0.2.5"
   },
   "system": {
+    "npmAlgorithm": "flat",
     "npmIgnore": [
       "testee",
       "grunt"

--- a/test/css-instantiated/build.js
+++ b/test/css-instantiated/build.js
@@ -1,0 +1,9 @@
+var stealTools = require("steal-tools");
+
+var promise = stealTools.build({
+	main: "main",
+	config: __dirname+"/stealconfig.js"
+},{
+	minify: false,
+	debug: true
+});

--- a/test/css-instantiated/main.css
+++ b/test/css-instantiated/main.css
@@ -1,0 +1,3 @@
+.btn-danger {
+	background-color: #f00;
+}

--- a/test/css-instantiated/main.js
+++ b/test/css-instantiated/main.js
@@ -1,0 +1,17 @@
+"format cjs";
+
+require("main.css");
+
+var btn = document.getElementById('test-element');
+var links = document.getElementsByTagName('link');
+
+if (typeof window !== "undefined" && window.QUnit) {
+
+	QUnit.notEqual(links.length, 2, "not append the same stylesheet again");
+	QUnit.equal(getComputedStyle(btn).backgroundColor, 'rgb(255, 0, 0)', 'css applied');
+
+	QUnit.start();
+	removeMyself();
+}else{
+	console.log(getComputedStyle(btn));
+}

--- a/test/css-instantiated/prod.html
+++ b/test/css-instantiated/prod.html
@@ -1,0 +1,24 @@
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Test</title>
+
+	<link rel="stylesheet" href="dist/bundles/main.css">
+	<script type="text/javascript"
+			src="../../node_modules/steal/steal.js"
+			main="main"
+			config="stealconfig.js"
+			env="production">
+	</script>
+
+</head>
+<body>
+
+<div id="test-element" class="btn btn-danger">BUTTON</div>
+<script>
+	window.QUnit = window.parent.QUnit;
+	window.removeMyself = window.parent.removeMyself;
+</script>
+
+</body>
+</html>

--- a/test/css-instantiated/stealconfig.js
+++ b/test/css-instantiated/stealconfig.js
@@ -1,0 +1,6 @@
+steal.config({
+	paths: {
+		"$css": "../../css.js"
+	},
+	baseUrl: "test/css-instantiated/"
+});

--- a/test/test.js
+++ b/test/test.js
@@ -22,4 +22,8 @@ asyncTest("url paths in production works", function(){
 	makeIframe("css_paths/prod.html");
 });
 
+asyncTest("css instantiated hack", function(){
+	makeIframe("css-instantiated/prod.html");
+});
+
 QUnit.start();


### PR DESCRIPTION
revert the npm algorithm because this plugin can be also used with steal < 1.0

add the possibility not to add a instantiated css file manually in the steal.instantiated object.
http://stealjs.com/docs/System.instantiated.html

close https://github.com/stealjs/steal-css/issues/17