### PR TITLE
make promise based css appending work with zombie.js

### DIFF
--- a/css.js
+++ b/css.js
@@ -77,6 +77,11 @@ if(isProduction()) {
 
 			document.head.appendChild(link);
 
+			// if after appending link styleSheet and the length is still 0 we call always loadCB()
+			// this is a bad workaround for the Zombie.js browser
+			if(document.styleSheets.length === 0) {
+				loadCB();
+			}
 		});
 	};
 


### PR DESCRIPTION
tests with zombie.js fail, because it seems that zombie.js will not append stylesheets links to the document head
```
document.head.appendChild(link);
```
so `loadCb()` will never called and the promise is rejected and the JS code is not executed!

