### PR TITLE
new signature for CSSModule

### DIFF
--- a/docs/cssmodule.md
+++ b/docs/cssmodule.md
@@ -6,6 +6,14 @@
 
 `CSSModule` is a constructor function that is used for loading a `.css` module. This is mostly useful for CSS plugins that seek to inherit base behavior from [steal-css].
 
+@signature `new CSSModule(load, loader)`
+
+Creates a new instance of CSSModule for the load.
+
+@param {Object} load The load object of this module.
+
+@param {Loader} loader The loader loading the module.
+
 @signature `new CSSModule(address, source)`
 
 Creates a new instance of CSSModule with the given address and source.
@@ -25,7 +33,7 @@ var CSSModule = require("steal-css").CSSModule;
 
 ...
 
-var css = new CSSModule(address, source);
+var css = new CSSModule(load, loader);
 ```
 
 Depending on whether you are trying to inject a `<style>` tag or a `<link>` tag use the methods [steal-css.CSSModule.prototype.injectStyle] or [steal-css.CSSModule.prototype.injectLink].

--- a/docs/steal-css.md
+++ b/docs/steal-css.md
@@ -8,6 +8,7 @@
 **steal-css** is a plugin for Steal that helps with loading CSS.
 
 @option {steal-css.CSSModule} CSSModule The CSSModule property is a constructor function that facilitates most of what steal-css provides. End users never need to use this functionality, it is provided for plugin authors that seek to extend steal-css' core behavior.
+@option {function} getDocument Retrieves the document of the page, or the server-side rendering document.
 
 @body
 


### PR DESCRIPTION
The CSSModule constructor has a new signature that receives the load
object and the loader. These are needed for done-css, which does a bit
more than what steal-css needs.