### PR TITLE
steal-css mapped to $css

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,15 +28,17 @@
   "devDependencies": {
     "bit-docs": "0.0.6",
     "qunitjs": "~1.12.0",
-    "steal": "^1.0.0-rc",
-    "steal-tools": "^1.0.0-rc.6",
+    "steal": "^1.0.0",
+    "steal-tools": "^1.0.0",
     "testee": "^0.2.5"
   },
   "steal": {
     "ext": {
       "css": "steal-css"
     },
-    "npmIgnore": ["testee"]
+    "map": {
+      "$css": "steal-css"
+    }
   },
   "bit-docs": {
     "dependencies": {

--- a/test/dollar-css/dev.html
+++ b/test/dollar-css/dev.html
@@ -1,0 +1,9 @@
+<body>
+	<div class="btn btn-danger">BUTTON</div>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+	<script src="../../node_modules/steal/steal.js"
+		main="test/dollar-css/main"></script>
+</body>

--- a/test/dollar-css/main.css
+++ b/test/dollar-css/main.css
@@ -1,0 +1,3 @@
+.btn {
+	background: green;
+}

--- a/test/dollar-css/main.js
+++ b/test/dollar-css/main.js
@@ -1,0 +1,13 @@
+require("./main.css!$css");
+
+var btn = document.querySelector(".btn");
+var s = getComputedStyle(btn);
+
+if(typeof window !== "undefined" && window.QUnit) {
+	QUnit.equal(s.backgroundColor, 'rgb(0, 128, 0)');
+
+	QUnit.start();
+	removeMyself();
+} else {
+	console.log(s.backgroundColor);
+}

--- a/test/test.js
+++ b/test/test.js
@@ -26,4 +26,8 @@ asyncTest("css instantiated hack", function(){
 	makeIframe("css-instantiated/prod.html");
 });
 
+asyncTest("steal-css is mapped as $css", function(){
+	makeIframe("dollar-css/dev.html");
+});
+
 QUnit.start();


### PR DESCRIPTION
This maps steal-css to $css so that modules like steal-less can depend
on that and when another $css exists (like done-css) that overwrites it,
   that is used instead.

Closes #28