### PR TITLE
Throw when there isn't a global document

### DIFF
--- a/css.js
+++ b/css.js
@@ -27,7 +27,11 @@ function getDocument() {
 		return doneSsr.globalDocument;
 	}
 
-	return typeof document === "undefined" ? undefined : document;
+	if(typeof document !== "undefined") {
+		return document;
+	}
+
+	throw new Error("Unable to load CSS in an environment without a document.");
 }
 
 function getHead() {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "bit-docs": "0.0.6",
     "qunitjs": "~1.12.0",
     "steal": "^1.0.0",
+    "steal-qunit": "^1.0.0",
+    "steal-test-helpers": "^0.2.0",
     "steal-tools": "^1.0.0",
     "testee": "^0.2.5"
   },
@@ -56,5 +58,4 @@
     },
     "parent": "steal-css"
   }
-
 }

--- a/test/css_paths/config.js
+++ b/test/css_paths/config.js
@@ -7,8 +7,6 @@ steal.config({
 	paths: {
 		"bootstrap/*": "folder/bootstrap/*",
 		"steal-css": "../../css.js",
-		"helpers": "../helpers.js"
+		"helpers": "./helpers.js"
 	}
 });
-
-

--- a/test/css_paths/helpers.js
+++ b/test/css_paths/helpers.js
@@ -1,13 +1,3 @@
-var steal = require("@steal");
-var helpers = require("steal-test-helpers")(steal);
-var pkg = require("../package.json");
-
-exports.clone = function(){
-	var sName = "steal-css@" + pkg.version + "#css";
-	var sSource = steal.loader.getModuleLoad(sName).source;
-
-	return helpers.clone().withModule("steal-css", sSource);
-};
 
 exports.waitForCssRules = function(styleNode, callback) {
 	if (typeof callback !== 'function') {

--- a/test/test.html
+++ b/test/test.html
@@ -2,23 +2,10 @@
 <html>
 	<head>
 		<title>steal-css tests</title>
-		<link rel="stylesheet" type="text/css" href="../node_modules/qunitjs/qunit/qunit.css"/>
 	</head>
 
 	<body>
-		<h1 id="qunit-header">steal-css test suite</h1>
-
-		<h2 id="qunit-banner"></h2>
-		<div id="qunit-testrunner-toolbar"></div>
-		<h2 id="qunit-userAgent"></h2>
-		<ol id="qunit-tests"></ol>
 		<div id="qunit-test-area"></div>
-
-		<script src="../node_modules/qunitjs/qunit/qunit.js"></script>
-		<script src="../node_modules/steal/steal.js" main="@empty"></script>
-		<script type="text/javascript">
-			QUnit.config.autostart = false;
-		</script>
-		<script src="test.js"></script>
+		<script src="../node_modules/steal/steal.js" main="test/test"></script>
 	</body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,5 @@
+var QUnit = require("steal-qunit");
+
 QUnit.module("steal-css plugin");
 
 var makeIframe = function(src){
@@ -30,4 +32,4 @@ asyncTest("steal-css is mapped as $css", function(){
 	makeIframe("dollar-css/dev.html");
 });
 
-QUnit.start();
+require("./unit");

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,0 +1,33 @@
+var helpers = require("./helpers");
+var QUnit = require("steal-qunit");
+
+QUnit.module("SSR", {
+	setup: function(){
+
+	}
+});
+
+// Skipping this for now as I can't find a good way to mock the global document
+QUnit.skip("Throws if there is not a document", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			version: "1.0.0",
+			main: "main.js"
+		})
+		.allowFetch("app@1.0.0#app.css!steal-css")
+		.loader;
+
+	loader.env = "production";
+
+	loader["import"]("app/app.css!steal-css")
+	.then(function(){
+		console.log('here');
+		QUnit.ok(false, "This should have failed");
+	}, function(err){
+		console.log('erro', err, err.stack);
+	})
+	.then(done, done);
+});


### PR DESCRIPTION
When there is no global document or a doneSsr.document we should throw
because it means that steal-css is unable to load the CSS module in any
way. This provides clearer indication of a downstream problem.

Closes #30