### PR TITLE
Fixes issue #44

### DIFF
--- a/css.js
+++ b/css.js
@@ -119,11 +119,13 @@ CSSModule.prototype = {
 			// Weak inference targets Android < 4.4 and
 			// a fallback for IE 8 and beneath
 			if( "isApplicationInstalled" in navigator ||
-				// Zombie
-				navigator.noUI ||
+				
 				!link.addEventListener) {
 				// fallback, polling styleSheets
 				onloadCss(link, loadCB);
+			} else if(navigator.noUI){
+				// Zombie
+				loadCB();
 			} else {
 				// attach onload event for all modern browser
 				link.addEventListener( "load", loadCB );

--- a/css.js
+++ b/css.js
@@ -115,9 +115,12 @@ CSSModule.prototype = {
 			//	* Android 4.3 (Samsung Galaxy S4, Browserstack)
 			//	* Android 4.2 Browser (Samsung Galaxy SIII Mini GT-I8200L)
 			//	* Android 2.3 (Pantech Burst P9070)
+			//  * Zombie headless browser
 			// Weak inference targets Android < 4.4 and
 			// a fallback for IE 8 and beneath
 			if( "isApplicationInstalled" in navigator ||
+				// Zombie
+				navigator.noUI ||
 				!link.addEventListener) {
 				// fallback, polling styleSheets
 				onloadCss(link, loadCB);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -52,6 +52,15 @@ exports.fakeBeingInNode = function() {
 	};
 };
 
+exports.fakeBeingInZombie = function() {
+	navigator.noUI = true;
+
+	return function(){
+		var global = steal.loader.global;
+		delete global.navigator.noUI;
+	};
+};
+
 /**
  * A promise based polling function
  * @param {Function} pred A predicate function


### PR DESCRIPTION
- [Detect Zombie and bypass `addEventListener`](https://github.com/stealjs/steal-css/pull/45/commits/07ce09ac2271c53eed7894c1f2ed39f4945af7fb)
- [Added helper for faking Zombie](https://github.com/stealjs/steal-css/compare/44-fix-zombie-tests?expand=1#diff-42a353e98c906af524c7d3d48feaf72aR55)
- [Added test for running in Zombie](https://github.com/stealjs/steal-css/compare/44-fix-zombie-tests?expand=1#diff-a11d42d80e96bd0a929b68d115fc7759R54)
- [Stopped faking Node before every test](https://github.com/stealjs/steal-css/compare/44-fix-zombie-tests?expand=1#diff-a11d42d80e96bd0a929b68d115fc7759R4)
- Gained hatred for Firefox