### PR TITLE
Fix style tag insertion in MS Edge

### DIFF
--- a/css.js
+++ b/css.js
@@ -119,7 +119,6 @@ CSSModule.prototype = {
 			// Weak inference targets Android < 4.4 and
 			// a fallback for IE 8 and beneath
 			if( "isApplicationInstalled" in navigator ||
-				
 				!link.addEventListener) {
 				// fallback, polling styleSheets
 				onloadCss(link, loadCB);
@@ -146,11 +145,16 @@ CSSModule.prototype = {
 		// make source load relative to the current page
 		style.type = 'text/css';
 
-		if (style.styleSheet){
+		// Starting with IE11, `styleSheet` isn't support but `sheet` is
+		// https://msdn.microsoft.com/en-us/library/dd347030(v=vs.85).aspx
+		if (style.sheet) {
+			style.sheet.cssText = this.source;
+		} else if (style.styleSheet) {
 			style.styleSheet.cssText = this.source;
 		} else {
 			style.appendChild(doc.createTextNode(this.source));
 		}
+
 		head.appendChild(style);
 	},
 

--- a/test/saucelabs.js
+++ b/test/saucelabs.js
@@ -36,7 +36,7 @@ var platforms = [{
 	version: '9'
 }, {
 	browserName: 'Safari',
-	'appium-version': '1.6.0',
+	'appium-version': '1.6.4',
 	platformName: 'iOS',
 	platformVersion: '10.0',
 	deviceName: 'iPhone 7 Simulator'


### PR DESCRIPTION
Starting from IE11 the `styleSheet` property is not supported, Edge will insert the tag if `styleSheet` is set but it won't apply the styles. Same thing if either `appendChild`, `innerText`, `textContent` or `innerHtml` is set; the only way to make Edge apply the style is by setting `style.sheet`

tag inserted but styles not applied
![bs_win10_edge_15 0 1](https://user-images.githubusercontent.com/724877/27606475-b9245280-5b3d-11e7-901f-8dbbf9778a51.jpg)

The styles were applied but for some reason the style tag is shown empty
![bs_win10_edge_15 0](https://user-images.githubusercontent.com/724877/27606486-c541bfa8-5b3d-11e7-99ae-3636d9be34b6.jpg)

![ltpr5jb](https://user-images.githubusercontent.com/724877/27606538-f90c0a0a-5b3d-11e7-8b1b-58d74c7460f4.gif)


